### PR TITLE
fix(payment): migrate stripe.charges.create -> stripe.paymentIntents.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "Demo for Lab 3.2",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --runInBand"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "stripe": "^18.4.0"
+  },
+  "devDependencies": {
+    "jest": "^30.0.5"
   }
 }

--- a/payment.js
+++ b/payment.js
@@ -1,16 +1,26 @@
-const stripe = require('stripe')('sk_test_yourSecretKey');
+// payment.js
+const stripeLib = require('stripe');
+
+const stripe = stripeLib(process.env.STRIPE_SECRET_KEY || 'sk_test_YOUR_TEST_KEY');
 
 async function processPayment(amount, currency = 'usd', paymentMethod) {
-    // Deprecated method - needs to be updated
-    return await stripe.charges.create({
-        amount: amount,
-        currency: currency,
-        source: paymentMethod,
-        description: 'Order Payment'
-    });
+  if (!amount || !paymentMethod) {
+    throw new Error('Missing required parameter: amount and paymentMethod are required');
+  }
+
+  // Create a PaymentIntent and confirm it immediately
+  const paymentIntent = await stripe.paymentIntents.create({
+    amount: amount,
+    currency: currency,
+    payment_method: paymentMethod,
+    description: 'Order Payment',
+    confirm: true,
+  });
+
+  return paymentIntent;
 }
 
-// Example usage (don’t use real card details in testing)
-processPayment(5000, 'usd', 'pm_card_visa')
-    .then(res => console.log(res))
-    .catch(err => console.error(err));
+// export for testing
+module.exports = {
+  processPayment
+};

--- a/payment.test.js
+++ b/payment.test.js
@@ -1,0 +1,31 @@
+// payment.test.js
+jest.mock('stripe');
+
+const stripeMock = require('stripe');
+
+const fakeCreate = jest.fn().mockResolvedValue({ id: 'pi_test_123', status: 'succeeded' });
+
+stripeMock.mockImplementation(() => {
+  return {
+    paymentIntents: {
+      create: fakeCreate
+    }
+  };
+});
+
+const { processPayment } = require('./payment');
+
+describe('processPayment', () => {
+  test('should create and return a PaymentIntent', async () => {
+    const amount = 5000;
+    const result = await processPayment(amount, 'usd', 'pm_card_visa');
+
+    expect(fakeCreate).toHaveBeenCalled();
+    expect(result).toHaveProperty('id', 'pi_test_123');
+    expect(result).toHaveProperty('status', 'succeeded');
+  });
+
+  test('throws error when params missing', async () => {
+    await expect(processPayment(null, 'usd', null)).rejects.toThrow('Missing required parameter');
+  });
+});


### PR DESCRIPTION
…create and add tests## Title
fix(payment): migrate stripe.charges.create -> stripe.paymentIntents.create

## Description
This PR replaces deprecated `stripe.charges.create` with `stripe.paymentIntents.create` and adds unit tests. See issue #<issue-number>.

## Changes
- `payment.js` updated to use PaymentIntent API
- `payment.test.js` new unit tests (Jest) mocking Stripe
- `package.json` test script (if updated)

## Testing
- `npm test` passes locally
- PaymentIntent creation is mocked in tests

## References
- https://stripe.com/docs/payments/payment-intents
- https://stripe.com/docs/api/charges (deprecated)
